### PR TITLE
Fix VSCode environment for postcss

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,8 +20,12 @@
   "[svelte]": {
     "editor.defaultFormatter": "svelte.svelte-vscode"
   },
+  "svelte.plugin.css.enable": false,
   "svelte.plugin.css.diagnostics.enable": false,
   "css.validate": false,
   "less.validate": false,
-  "scss.validate": false
+  "scss.validate": false,
+  "i18n-ally.localesPaths": [
+    "assets/translations"
+  ]
 }

--- a/src/components/pages/Intro.svelte
+++ b/src/components/pages/Intro.svelte
@@ -1,4 +1,4 @@
-<style lang="scss">
+<style lang="postcss">
   main {
     display: flex;
     flex-direction: column;

--- a/src/components/pages/SignIn.svelte
+++ b/src/components/pages/SignIn.svelte
@@ -1,4 +1,4 @@
-<style lang="scss">
+<style lang="postcss">
   main {
     grid-template-columns: 1fr;
     grid-template-rows: 1fr;
@@ -68,8 +68,8 @@
   const onChangeEmail = (e: CustomEvent) => {
     email = e.detail;
   };
- 
- const onChangePassword = (e: CustomEvent) => {
+
+  const onChangePassword = (e: CustomEvent) => {
     password = e.detail;
   };
 

--- a/src/components/pages/SignUp.svelte
+++ b/src/components/pages/SignUp.svelte
@@ -1,4 +1,4 @@
-<style lang="scss">
+<style lang="postcss">
   main {
     .icon {
       &:hover {

--- a/src/components/pages/__tests__/__snapshots__/Intro.test.ts.snap
+++ b/src/components/pages/__tests__/__snapshots__/Intro.test.ts.snap
@@ -4,14 +4,14 @@ exports[`should render without error 1`] = `
 <body>
   <div>
     <main
-      class="svelte-1veuz41"
+      class="svelte-1q6pbdh"
     >
       <p>
         Hello there ~ 🙌 Welcome to WeCount.
       </p>
        
       <button
-        class="svelte-15wiqim"
+        class="svelte-kxtdq7"
         style=""
         type=""
         value=""
@@ -20,7 +20,7 @@ exports[`should render without error 1`] = `
       </button>
        
       <button
-        class="svelte-15wiqim"
+        class="svelte-kxtdq7"
         style=""
         type=""
         value=""

--- a/src/components/uis/Button.svelte
+++ b/src/components/uis/Button.svelte
@@ -1,4 +1,4 @@
-<style lang="scss">
+<style lang="postcss">
   button {
     background-color: var(--button);
     color: var(--text);
@@ -27,14 +27,13 @@
   function handleClick() {
     dispatch('click');
   }
-
 </script>
 
 <button
-  {type}
-  {style}
-  {value}
-  {disabled}
+  type={type}
+  style={style}
+  value={value}
+  disabled={disabled}
   on:click|preventDefault={handleClick}
 >
   <slot />

--- a/src/components/uis/EditText.svelte
+++ b/src/components/uis/EditText.svelte
@@ -1,4 +1,5 @@
-<style lang="scss">
+<!-- svelte-ignore css-unused-selector -->
+<style lang="postcss">
   main {
     border: 1px solid var(--border);
     box-sizing: border-box;
@@ -8,6 +9,10 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+
+    &:focus-within {
+      border: 1px solid var(--input-focus);
+    }
 
     input {
       flex: 1;
@@ -29,10 +34,6 @@
         -webkit-box-shadow: 0 0 0 1000px var(--background-color) inset !important;
       }
     }
-  }
-
-  main:focus-within {
-    border: 1px solid var(--input-focus);
   }
 </style>
 

--- a/src/components/uis/__tests__/__snapshots__/Button.test.ts.snap
+++ b/src/components/uis/__tests__/__snapshots__/Button.test.ts.snap
@@ -4,7 +4,7 @@ exports[`should render without error 1`] = `
 <body>
   <div>
     <button
-      class="svelte-15wiqim"
+      class="svelte-kxtdq7"
       style=""
       type=""
       value=""


### PR DESCRIPTION
Correctly configure postcss in vscode.

Ignore the wrong warnings for `css-unused-selector` as described in sveltejs/language-tools#457

- Closes #17 