### PR TITLE
Enhance responsive design for auth pages in mobile

### DIFF
--- a/src/components/pages/SignIn.svelte
+++ b/src/components/pages/SignIn.svelte
@@ -22,11 +22,20 @@
       background: #ffffff;
       box-shadow: 0px 24px 42px rgba(0, 0, 0, 0.08);
       border-radius: 16px;
+      max-height: 654px;
+      max-width: 640px;
+      align-self: center;
 
       display: flex;
       flex-direction: column;
       justify-content: center;
       align-items: center;
+
+      @media (max-width: 640px) {
+        width: 100%;
+        border-radius: 0;
+        padding: 0;
+      }
 
       .container-options {
         align-self: stretch;

--- a/src/components/pages/SignUp.svelte
+++ b/src/components/pages/SignUp.svelte
@@ -33,9 +33,21 @@
       background: #ffffff;
       box-shadow: 0px 24px 42px rgba(0, 0, 0, 0.08);
       border-radius: 16px;
+      max-height: 488px;
+      max-width: 640px;
+      align-self: center;
+
+      @media (max-width: 640px) {
+        max-height: none;
+        border-radius: 0;
+        padding: 80px 24px;
+
+        flex: 1;
+      }
 
       display: grid;
       grid-template-areas:
+        ' . . . '
         'header header header '
         ' . . . '
         'label input input'
@@ -43,9 +55,15 @@
         'label input input'
         'terms terms terms'
         ' . . . '
-        'btn-sign btn-sign btn-sign';
-      grid-template-columns: 1fr 1fr 1fr;
+        'btn-sign btn-sign btn-sign'
+        ' . . . ';
       justify-content: stretch;
+
+      @media (max-width: 640px) {
+        grid-template-columns: none;
+        grid-template-rows: min-content;
+        align-content: stretch;
+      }
 
       .header {
         grid-area: header;
@@ -59,13 +77,16 @@
       .label {
         grid-area: label;
 
-        display: grid;
-        align-items: stretch;
+        display: flex;
+        flex-direction: column;
 
         p {
           font-size: 14px;
-          line-height: 260%;
           letter-spacing: -0.5px;
+
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
         }
       }
 
@@ -88,7 +109,7 @@
           align-items: center;
 
           p {
-            margin-left: 6px;
+            margin-left: 8px;
             font-style: normal;
             letter-spacing: -0.5px;
             font-weight: normal;
@@ -96,8 +117,7 @@
             line-height: 21px;
 
             display: flex;
-            flex-direction: row;
-            align-items: center;
+            flex-wrap: wrap;
           }
         }
       }
@@ -219,7 +239,7 @@
     </div>
     <div class="terms">
       <div class="container icon" on:click={handleCheck}>
-        <SvgCheck fill={checked ? '#0DB293' : 'none'} />
+        <SvgCheck width={34} fill={checked ? '#0DB293' : 'none'} />
         <p>
           {@html $_('SignUp.terms_and_agreement')}
         </p>


### PR DESCRIPTION
Fix UI looking ugly on the mobile page. Although we do not have the mobile design, it'd be better to support a minimal look and feel.

SignUp Page

|  As Is   |  To Be    |
|---	|---	|
| <img width="200" alt="SIgnUp - ASIS" src="https://user-images.githubusercontent.com/27461460/127802218-e6895582-33f4-4a93-95e0-7d2946d4bf1f.png">  	|  <img width="200" alt="Screen Shot 2021-08-02 at 1 11 19 PM" src="https://user-images.githubusercontent.com/27461460/127803318-d71320cb-61d2-4e89-b666-eb5332de4116.png"> 	|

SignIn Page

|  As Is   |  To Be    |
|---	|---	|
| <img width="200" alt="SignIn - ASIS" src="https://user-images.githubusercontent.com/27461460/127802248-ef361bd3-45da-4f7d-a925-9580db11e114.png">  	|   <img width="200" alt="SignIn - TOBE" src="https://user-images.githubusercontent.com/27461460/127802263-37f42f47-ffd0-466c-9d62-637788d1f2c7.png"> 	|
