### PR TITLE
Resolve a typescript error in functions

### DIFF
--- a/functions/.eslintrc.js
+++ b/functions/.eslintrc.js
@@ -1,0 +1,11 @@
+{
+  overrides: [
+    {
+      files: ['*.ts'],
+      parserOptions: {
+        project: ['./tsconfig.json'],
+      },
+    }
+  ],
+  parser: '@typescript-eslint/parser',
+}

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -7,3 +7,7 @@ typings/
 
 # Node.js dependency directory
 node_modules/
+
+
+firebase-debug.log
+ui-debug.log


### PR DESCRIPTION
Typescript error is occurred in `functions`. It may happened since there is no setting about project's `parseOptions`. 
I followed by this [answer](https://stackoverflow.com/questions/58510287/parseroptions-project-has-been-set-for-typescript-eslint-parser/64488474#64488474), then it is fixed. 

![image](https://user-images.githubusercontent.com/58724686/127852370-f548a38c-88db-4154-ae90-a8cd4df44b8e.png)
