### PR TITLE
BugFix: Select overlab zindex error & background theme

### DIFF
--- a/src/components/uis/Select.svelte
+++ b/src/components/uis/Select.svelte
@@ -13,6 +13,7 @@
     border-color: var(--gray30);
     box-sizing: border-box;
     border-radius: 4px;
+    background-color: var(--background-color);
 
     &:hover {
       cursor: pointer;
@@ -32,6 +33,7 @@
     box-shadow: 0px 4px 10px 0px rgba(196, 196, 196, 0.5);
     border-radius: 4px;
     overflow: hidden;
+    z-index: 99;
   }
   .option {
     height: 36px;


### PR DESCRIPTION
# Before
issue #43 

# After
https://user-images.githubusercontent.com/48207131/128601605-07cde491-8b7c-4cf6-97f1-2fed96084bc7.mov

+ change background-color to ```var(--background-color)```

Closes #43