### PR TITLE
[Refector] FeedScreen list-container width

### DIFF
--- a/src/components/pages/Feed/Feed.svelte
+++ b/src/components/pages/Feed/Feed.svelte
@@ -5,12 +5,12 @@
     align-items: flex-end;
   }
   .list-container {
-    width: 800px;
+    width: 720px;
     display: flex;
     flex-direction: column;
     position: relative;
     align-items: flex-end;
-    margin-right: 200px;
+    margin-right: 240px;
     @media (max-width: 1200px) {
       width: 100%;
       margin-right: 0px;


### PR DESCRIPTION
* FeedCard width: 800px; -> 720px;
* from https://github.com/wecount-dev/wecount/pull/103#pullrequestreview-746670211

<img width="1792" alt="스크린샷 2021-09-06 오후 4 26 54" src="https://user-images.githubusercontent.com/48207131/132177292-df923e72-0f87-43c3-a561-0839dc03b019.png">
