### PR TITLE
Set default export components

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -131,7 +131,7 @@
   import './i18n';
   import {user} from './stores/sessionStore';
   import supabase from './lib/db';
-  import Main from './components/navigations/Main/index.svelte';
+  import {Main} from './components/navigations/Main';
   import {upsertUser} from './services/userService';
   import relativeTime from 'dayjs/plugin/relativeTime';
   import 'dayjs/locale/ko';

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -131,7 +131,7 @@
   import './i18n';
   import {user} from './stores/sessionStore';
   import supabase from './lib/db';
-  import {Main} from './components/navigations/Main';
+  import Main from './components/navigations/Main';
   import {upsertUser} from './services/userService';
   import relativeTime from 'dayjs/plugin/relativeTime';
   import 'dayjs/locale/ko';

--- a/src/components/navigations/Community/Drawer/index.ts
+++ b/src/components/navigations/Community/Drawer/index.ts
@@ -1,0 +1,1 @@
+export {default as Drawer} from './index.svelte';

--- a/src/components/navigations/Community/Drawer/index.ts
+++ b/src/components/navigations/Community/Drawer/index.ts
@@ -1,1 +1,1 @@
-export {default as Drawer} from './index.svelte';
+export {default} from './index.svelte';

--- a/src/components/navigations/Community/index.svelte
+++ b/src/components/navigations/Community/index.svelte
@@ -25,7 +25,7 @@
 <script lang="ts">
   import Dashboard from '../../pages/dashboard/Index.svelte';
   import Router from 'svelte-spa-router';
-  import Drawer from './Drawer/index.svelte';
+  import {Drawer} from './Drawer';
   import Temp from '../../pages/Temp.svelte';
   import Member from '../../pages/Member/Member.svelte';
   import Feed from '../../pages/Feed/Feed.svelte';

--- a/src/components/navigations/Community/index.svelte
+++ b/src/components/navigations/Community/index.svelte
@@ -25,7 +25,7 @@
 <script lang="ts">
   import Dashboard from '../../pages/dashboard/Index.svelte';
   import Router from 'svelte-spa-router';
-  import {Drawer} from './Drawer';
+  import Drawer from './Drawer';
   import Temp from '../../pages/Temp.svelte';
   import Member from '../../pages/Member/Member.svelte';
   import Feed from '../../pages/Feed/Feed.svelte';

--- a/src/components/navigations/Community/index.ts
+++ b/src/components/navigations/Community/index.ts
@@ -1,1 +1,1 @@
-export {default as CommunityRoute} from './index.svelte';
+export {default} from './index.svelte';

--- a/src/components/navigations/Community/index.ts
+++ b/src/components/navigations/Community/index.ts
@@ -1,0 +1,1 @@
+export {default as CommunityRoute} from './index.svelte';

--- a/src/components/navigations/Main/Header/MainHeader/index.ts
+++ b/src/components/navigations/Main/Header/MainHeader/index.ts
@@ -1,1 +1,1 @@
-export {default as MainHeader} from './index.svelte';
+export {default} from './index.svelte';

--- a/src/components/navigations/Main/Header/MainHeader/index.ts
+++ b/src/components/navigations/Main/Header/MainHeader/index.ts
@@ -1,0 +1,1 @@
+export {default as MainHeader} from './index.svelte';

--- a/src/components/navigations/Main/Header/index.svelte
+++ b/src/components/navigations/Main/Header/index.svelte
@@ -31,7 +31,7 @@
   import {user} from '../../../../stores/sessionStore';
   import {SvgLogo} from '../../../../utils/Icon';
   import AuthHeader from './AuthHeader.svelte';
-  import MainHeader from './MainHeader/index.svelte';
+  import {MainHeader} from './MainHeader';
 </script>
 
 <nav>

--- a/src/components/navigations/Main/Header/index.svelte
+++ b/src/components/navigations/Main/Header/index.svelte
@@ -31,7 +31,7 @@
   import {user} from '../../../../stores/sessionStore';
   import {SvgLogo} from '../../../../utils/Icon';
   import AuthHeader from './AuthHeader.svelte';
-  import {MainHeader} from './MainHeader';
+  import MainHeader from './MainHeader';
 </script>
 
 <nav>

--- a/src/components/navigations/Main/Header/index.ts
+++ b/src/components/navigations/Main/Header/index.ts
@@ -1,0 +1,1 @@
+export {default as Header} from './index.svelte';

--- a/src/components/navigations/Main/Header/index.ts
+++ b/src/components/navigations/Main/Header/index.ts
@@ -1,1 +1,1 @@
-export {default as Header} from './index.svelte';
+export {default} from './index.svelte';

--- a/src/components/navigations/Main/index.svelte
+++ b/src/components/navigations/Main/index.svelte
@@ -13,13 +13,13 @@
 <script>
   import Router from 'svelte-spa-router';
   import Profile from '../../pages/Profile.svelte';
-  import {Header} from './Header';
+  import Header from './Header';
   import SignIn from '../../pages/SignIn.svelte';
   import SignUp from '../../pages/SignUp.svelte';
   import ServiceSample from '../../pages/ServiceSample.svelte';
   import Onboarding from '../../pages/Onboarding.svelte';
   import CommunityCreate from '../../pages/community/CommunityCreate.svelte';
-  import {CommunityRoute} from '../Community';
+  import CommunityRoute from '../Community';
   import Temp from '../../pages/Temp.svelte';
 
   const routes = {

--- a/src/components/navigations/Main/index.svelte
+++ b/src/components/navigations/Main/index.svelte
@@ -13,13 +13,13 @@
 <script>
   import Router from 'svelte-spa-router';
   import Profile from '../../pages/Profile.svelte';
-  import Header from './Header/index.svelte';
+  import {Header} from './Header';
   import SignIn from '../../pages/SignIn.svelte';
   import SignUp from '../../pages/SignUp.svelte';
   import ServiceSample from '../../pages/ServiceSample.svelte';
   import Onboarding from '../../pages/Onboarding.svelte';
   import CommunityCreate from '../../pages/community/CommunityCreate.svelte';
-  import CommunityRoute from '../Community/index.svelte';
+  import {CommunityRoute} from '../Community';
   import Temp from '../../pages/Temp.svelte';
 
   const routes = {

--- a/src/components/navigations/Main/index.ts
+++ b/src/components/navigations/Main/index.ts
@@ -1,0 +1,1 @@
+export {default as Main} from './index.svelte';

--- a/src/components/navigations/Main/index.ts
+++ b/src/components/navigations/Main/index.ts
@@ -1,1 +1,1 @@
-export {default as Main} from './index.svelte';
+export {default} from './index.svelte';


### PR DESCRIPTION
I improved the uncomfortable import with index.svelte. :)


I referred to the link below.
https://svelte.dev/repl/47e73637efe44b3e87962343b08adf77?version=3.24.0

On the one hand, I'm worried that having the names of two indexe(index.svlete, index.ts) will cause confusion.

If you give me your opinion, I will actively reflect it!