### PR TITLE
Corrected 404 error related to main.ts.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,7 +49,6 @@ export default {
 		file: 'public/build/bundle.js',
 	},
 	plugins: [
-		typescript(),
 		image(),
 		svelteSVG({
 			svgo: {}


### PR DESCRIPTION
Resolved https://github.com/wecount-dev/wecount/issues/108

This error occurred due to duplicate typescript plug-in settings in the rollup configuration.
Based on the solution of the link below, I left the setting of the inline source and confirmed that it works normally without errors.
https://github.com/sveltejs/template/issues/145

rollup.config.js
```js
plugins: [
  ....
  typescript({
    sourceMap: !production,
    inlineSources: !production,
  }),
  ...
]
```